### PR TITLE
Default request.user_agent to an empty string if undefined.

### DIFF
--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -56,7 +56,7 @@ class HoneyMiddlewareBase(object):
             "request.path": request.path,
             "request.remote_addr": request.META['REMOTE_ADDR'],
             "request.content_length": request.META.get('CONTENT_LENGTH', '0'),
-            "request.user_agent": request.META['HTTP_USER_AGENT'],
+            "request.user_agent": request.META.get('HTTP_USER_AGENT', ''),
             "request.scheme": request.scheme,
             "request.secure": request.is_secure(),
             "request.query": request.GET.dict(),


### PR DESCRIPTION
Some bots/problematic users with browser the site without sending an HTTP_USER_AGENT this causes the middleware to break.

This fix will set `request.user_agent` to be an empty string if HTTP_USER_AGENT is not in the request.